### PR TITLE
README fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.txt

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,28 @@
+==========================
+Postmaster Python bindings
+==========================
+
+Installation
+============
+
+You don't need this source code unless you want to modify the
+package. If you just want to use the Postmaster Python bindings, you
+should run::
+
+    easy_install postmaster
+
+See http://www.pip-installer.org/en/latest/index.html for instructions
+on installing pip. If you are on a system with easy_install but not
+pip, you can use easy_install instead. If you're not using virtualenv,
+you may have to prefix those commands with `sudo`. You can learn more
+about virtualenv at http://www.virtualenv.org/
+
+To install from source, run::
+
+    python setup.py install
+
+Documentation
+=============
+
+Please see https://www.postmaster.io/docs for the most up-to-date
+documentation.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from postmaster.version import VERSION
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.md')).read()
+README = open(os.path.join(here, 'README.txt')).read()
 
 
 requires = [
@@ -23,4 +23,3 @@ setup(name='postmaster',
       test_suite='test',
       install_requires=requires,
       )
-


### PR DESCRIPTION
Egg didn't want to install, because it could not find README.md - which was not included by default.

I created reST version of README, and also added MANIFEST.in to make sure README.txt would be included in egg.
